### PR TITLE
fix form select focus background

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -135,7 +135,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   }
   // Basic focus styles
   &:focus {
-    background: $input-focus-bg-color;
+    background-color: $input-focus-bg-color;
     border-color: $input-focus-border-color;
     outline: none;
   }


### PR DESCRIPTION
On form select:focus, background wipes out the background url (dropdown arrow).
